### PR TITLE
Add missing bounds validation

### DIFF
--- a/src/DxfLoader.js
+++ b/src/DxfLoader.js
@@ -124,7 +124,7 @@ export class DxfLoader {
                      indices ${scene.indices.byteLength} B
                      transforms ${scene.transforms.byteLength} B`);
     } else {
-      throw Error("Empty document")
+      throw new Error("Empty document")
     }
 
 

--- a/src/DxfLoader.js
+++ b/src/DxfLoader.js
@@ -1,9 +1,9 @@
-import { BatchingKey } from 'dxf-viewer/src/BatchingKey';
-import { MaterialKey } from 'dxf-viewer/src/MaterialKey';
-import { RBTree } from 'dxf-viewer/src/RBTree';
 import * as three from 'three';
-import { ColorCode, DxfScene3D } from './DxfScene3D';
+import { BatchingKey } from 'dxf-viewer/src/BatchingKey';
 import { DxfWorker } from './DxfWorker';
+import { MaterialKey } from 'dxf-viewer/src/MaterialKey';
+import { ColorCode, DxfScene3D } from './DxfScene3D';
+import { RBTree } from 'dxf-viewer/src/RBTree';
 
 /** Level in "message" events. */
 const MessageLevel = Object.freeze({
@@ -111,10 +111,10 @@ export class DxfLoader {
     }
 
     if (scene.bounds) {
-      const verticalExtent = scene.bounds.maxZ - scene.bounds.minZ;
-      this.isFlat = verticalExtent < 0.000000001;
+    const verticalExtent = scene.bounds.maxZ - scene.bounds.minZ;
+    this.isFlat = verticalExtent < 0.000000001;
 
-      console.log(`DXF scene:
+    console.log(`DXF scene:
                      isFlat ${this.isFlat}
                      vertical extent ${verticalExtent}
                      ${scene.batches.length} batches,
@@ -646,7 +646,7 @@ class Batch {
     //XXX line type
     const materialFactory =
       this.key.geometryType === BatchingKey.GeometryType.POINTS ||
-        this.key.geometryType === BatchingKey.GeometryType.POINT_INSTANCE
+      this.key.geometryType === BatchingKey.GeometryType.POINT_INSTANCE
         ? this.viewer._GetSimplePointMaterial
         : this.viewer._GetSimpleColorMaterial;
 

--- a/src/DxfLoader.js
+++ b/src/DxfLoader.js
@@ -1,9 +1,9 @@
-import * as three from 'three';
 import { BatchingKey } from 'dxf-viewer/src/BatchingKey';
-import { DxfWorker } from './DxfWorker';
 import { MaterialKey } from 'dxf-viewer/src/MaterialKey';
-import { ColorCode, DxfScene3D } from './DxfScene3D';
 import { RBTree } from 'dxf-viewer/src/RBTree';
+import * as three from 'three';
+import { ColorCode, DxfScene3D } from './DxfScene3D';
+import { DxfWorker } from './DxfWorker';
 
 /** Level in "message" events. */
 const MessageLevel = Object.freeze({
@@ -110,10 +110,11 @@ export class DxfLoader {
       }
     }
 
-    const verticalExtent = scene.bounds.maxZ - scene.bounds.minZ;
-    this.isFlat = verticalExtent < 0.000000001;
+    if (scene.bounds) {
+      const verticalExtent = scene.bounds.maxZ - scene.bounds.minZ;
+      this.isFlat = verticalExtent < 0.000000001;
 
-    console.log(`DXF scene:
+      console.log(`DXF scene:
                      isFlat ${this.isFlat}
                      vertical extent ${verticalExtent}
                      ${scene.batches.length} batches,
@@ -122,6 +123,11 @@ export class DxfLoader {
                      vertices ${scene.vertices.byteLength} B,
                      indices ${scene.indices.byteLength} B
                      transforms ${scene.transforms.byteLength} B`);
+    } else {
+      throw Error("Empty document")
+    }
+
+
 
     /* Instantiate all entities. */
     for (const batch of scene.batches) {
@@ -640,7 +646,7 @@ class Batch {
     //XXX line type
     const materialFactory =
       this.key.geometryType === BatchingKey.GeometryType.POINTS ||
-      this.key.geometryType === BatchingKey.GeometryType.POINT_INSTANCE
+        this.key.geometryType === BatchingKey.GeometryType.POINT_INSTANCE
         ? this.viewer._GetSimplePointMaterial
         : this.viewer._GetSimpleColorMaterial;
 


### PR DESCRIPTION
Add missing validation before accessing bounds to handle the following error:

```
proxy.ts:36  ERROR TypeError: Cannot read properties of null (reading 'maxZ')
    at DxfLoader.js:113:41
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (asyncToGenerator.js:3:1)
    at _next (asyncToGenerator.js:22:1)
    at _ZoneDelegate.invoke (zone.js:368:26)
    at Object.onInvoke (core.mjs:14424:33)
    at _ZoneDelegate.invoke (zone.js:367:52)
    at Zone.run (zone.js:129:43)
    at zone.js:1257:36
    at _ZoneDelegate.invokeTask (zone.js:402:31)
```

Works in same way as https://github.com/vagran/dxf-viewer/blob/2468af59659d816612f492cf1caceea587531d54/src/DxfViewer.js#L222