### PR TITLE
release: sync versions with upstream

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 SIA SPH Engineering
 Artyom Lebedev <artyom.lebedev@gmail.com>
+Pix4d SA

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Mozilla Public License Version 2.0
 ==================================
 
 Copyright (c) 2021 dxf-viewer contributors
-Copyright (c) 2024 Pix4D SA
+Copyright (c) 2024 dxf-3d-loader Pix4D SA
 
 1. Definitions
 --------------

--- a/README.md
+++ b/README.md
@@ -1,70 +1,47 @@
-# DXF viewer
+The project is a fork of https://github.com/vagran/dxf-viewer - Kudos to authors and contributors!
 
-*If you just need to view your DXF, [click here](https://vagran.github.io/dxf-viewer-example/).*
-
-This package provides DXF 2D viewer component written in JavaScript. It renders drawings using WebGL
-(via [three.js](https://threejs.org) library). It was carefully crafted with performance in mind,
-intended for drawing huge real-world files without performance problems.
-
-The usage example is available here: https://github.com/vagran/dxf-viewer-example-src
-
-Deployed demo: https://vagran.github.io/dxf-viewer-example/
-
-The package is released under the Mozilla Public License 2.0.
-
-*The viewer was initially published in the
-[corporate repository](https://github.com/ugcs/ugcs-dxf-viewer) (mostly dead now) and is used in
-production in [Atlas](https://atlas.ugcs.com) project.*
+# DXF loader 
 
 ## Install
 
 ```bash
-npm install dxf-viewer
+npm install dxf-3d-loader
 ```
 
-## Features
+## Sync with upstream
 
- * File fetching, parsing and preparation for rendering is separated in such a way that it can be
-   easily off-loaded to web-worker using provided helpers. So the most heavy-weight processing part
-   does not affect UI responsiveness. The example above demonstrates this technique.
- * Geometry batching - minimal number of rendering batches is created during file processing, thus
-   minimizing total required number of draw calls.
- * Instanced rendering - features which are rendered multiple times with different transforms (e.g.
-   DXF block instances) are rendered by a single draw call using instanced rendering WebGL feature.
- * Multiple fonts support. List of fonts can be specified for text rendering. Raw TTF files are
-   supported. Fonts are lazy-loaded, once a character encountered which glyph is not yet available
-   through already loaded fonts, next font is fetched and checked for the necessary glyph.
- * Layers - layers are taken into account when creating rendering batches so that they can be easily
-   hidden/shown.
+Sync happens through a rebase to keep the git history as simple as possible. Create a new pix4d release by appending a "+pix4d" to the package version and generate a new git tag, following the same pattern. For example:
 
-## Incomplete features
+The latest pulled version of the library is "1.0.42".
+Make the change in the package.json file:
 
-There are still many incomplete features. I will try to implement some of them when I have some
-time. Anything useful implemented in the corporate repository will be merged here as well.
+```diff
+-   "version": "1.0.42",
++   "version": "1.0.42+pix4d",
+```
 
- * Stream parsing for input file. Currently, mostly relying on dxf-parser package which is not
-   stream parser and thus buffers whole the file before parsing. This prevents from supporting big
-   DXF file (above gigabyte) due to string size limit in JS engine (also making unnecessary memory
-   waste for the buffer).
- * Text styling. Currently, text rendering is using just the specified fonts in the specified order.
-   DXF style and font attributes are ignored. Text glyphs are always rendered infilled.
- * Advanced formatting support for MTEXT (fonts, coloring, stacking).
- * Line patterns - all lines are rendered in continuous style for now. I am going to use 1-D texture
-   generated on preparation stage, texture coordinates (which should account pattern continuity flag
-   in DXF vertices attributes), and a dedicated shader to implement this feature.
- * Line patterns with shapes (e.g. with circles).
- * Wide lines. Currently, all lines are rendered as thin lines. Physical width is not implemented.
- * Variable width lines (i.e. with start and end width specified).
- * Smoothed polyline (curve-fit/spline-fit addition vertices).
- * Hatching
- * Block instancing in a grid. Grid attributes are ignored now.
- * Dimensions
- * Leaders
- * Non-UTF-8 file encoding support. Currently, such files are displayed incorrectly. `$DWGCODEPAGE`
-   parameter is ignored.
- * Full OCS support. Currently, it is assumed that entity extrusion direction is either +Z or -Z
-   (which is commonly used for features mirroring in CAD). Arbitrary directions is not properly
-   processed.
- * Many less commonly used DXF features.
+Next, commit the change:
 
-![samples](https://user-images.githubusercontent.com/6065976/143092164-cced2f5f-1af3-42a4-9a71-5dba68df06e7.png)
+```bash
+git commit -am "release: pix4d"
+```
+
+Next, tag the commit:
+
+```bash
+git tag "v1.0.42+pix4d"
+```
+And push changes to origin:
+
+```bash
+git push origin --tags
+```
+
+## Contributing
+
+Contribute directly to the main library https://github.com/vagran/dxf-viewer 
+
+## License
+
+This project is licensed under the terms of the
+[Mozilla Public License 2.0](https://choosealicense.com/licenses/mpl-2.0/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,74 @@
 {
-  "name": "dxf-viewer",
-  "version": "1.0.15",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "loglevel": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
-      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
-    },
-    "opentype.js": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
-      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
-      "requires": {
-        "string.prototype.codepointat": "^0.2.1",
-        "tiny-inflate": "^1.0.3"
-      }
-    },
-    "string.prototype.codepointat": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
-      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
-    },
-    "three": {
-      "version": "0.137.5",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.137.5.tgz",
-      "integrity": "sha512-rTyr+HDFxjnN8+N/guZjDgfVxgHptZQpf6xfL/Mo7a5JYIFwK6tAq3bzxYYB4Ae0RosDZlDuP+X5aXDXz+XnHQ=="
-    },
-    "tiny-inflate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    "name": "dxf-3d-loader",
+    "version": "1.0.19+pix4d.1",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "dxf-3d-loader",
+            "version": "1.0.19+pix4d.1",
+            "license": "Mozilla Public License 2.0",
+            "dependencies": {
+                "@types/three": "^0.144.0",
+                "loglevel": "^1.8.0",
+                "opentype.js": "^1.3.4",
+                "three": "^0.146.0"
+            }
+        },
+        "node_modules/@types/three": {
+            "version": "0.144.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.144.0.tgz",
+            "integrity": "sha512-psvEs6q5rLN50jUYZ3D4pZMfxTbdt3A243blt0my7/NcL6chaCZpHe2csbCtx0SOD9fI/XnF3wnVUAYZGqCSYg==",
+            "dependencies": {
+                "@types/webxr": "*"
+            }
+        },
+        "node_modules/@types/webxr": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.21.tgz",
+            "integrity": "sha512-geZIAtLzjGmgY2JUi6VxXdCrTb99A7yP49lxLr2Nm/uIK0PkkxcEi4OGhoGDO4pxCf3JwGz2GiJL2Ej4K2bKaA=="
+        },
+        "node_modules/loglevel": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+            "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
+            }
+        },
+        "node_modules/opentype.js": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+            "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+            "dependencies": {
+                "string.prototype.codepointat": "^0.2.1",
+                "tiny-inflate": "^1.0.3"
+            },
+            "bin": {
+                "ot": "bin/ot"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
+        },
+        "node_modules/string.prototype.codepointat": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+            "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
+        },
+        "node_modules/three": {
+            "version": "0.146.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
+            "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A=="
+        },
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+        }
     }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dxf-3d-loader",
-    "version": "0.0.3",
+    "version": "1.0.19+pix4d.1",
     "description": "JavaScript DXF 3D file loader",
     "main": "src/index.js",
     "author": "Pix4d SA",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.3",
     "description": "JavaScript DXF 3D file loader",
     "main": "src/index.js",
-    "author": "Artyom Lebedev<artyom.lebedev@gmail.com>",
+    "author": "Pix4d SA",
     "license": "Mozilla Public License 2.0",
     "repository": "https://github.com/Pix4D/dxf-3d-loader",
     "keywords": [

--- a/src/DxfLoader.js
+++ b/src/DxfLoader.js
@@ -1,9 +1,9 @@
 import * as three from 'three';
-import { BatchingKey } from 'dxf-viewer/src/BatchingKey';
-import { DxfWorker } from './DxfWorker';
-import { MaterialKey } from 'dxf-viewer/src/MaterialKey';
+import { BatchingKey } from './BatchingKey';
 import { ColorCode, DxfScene3D } from './DxfScene3D';
-import { RBTree } from 'dxf-viewer/src/RBTree';
+import { DxfWorker } from './DxfWorker';
+import { MaterialKey } from './MaterialKey';
+import { RBTree } from './RBTree';
 
 /** Level in "message" events. */
 const MessageLevel = Object.freeze({

--- a/src/DxfWorker.js
+++ b/src/DxfWorker.js
@@ -1,6 +1,6 @@
-import { DxfFetcher } from 'dxf-viewer/src/DxfFetcher';
-import { DxfScene3D } from './DxfScene3D';
 import opentype from 'opentype.js';
+import { DxfFetcher } from './DxfFetcher';
+import { DxfScene3D } from './DxfScene3D';
 
 const MSG_SIGNATURE = 'DxfWorkerMsg';
 

--- a/src/TextRenderer.js
+++ b/src/TextRenderer.js
@@ -1,8 +1,8 @@
-import { DxfScene3D, Entity } from './DxfScene3D';
+import { Matrix3, Vector2, Vector3 } from 'three';
 import { ShapePath } from 'three/src/extras/core/ShapePath';
 import { ShapeUtils } from 'three/src/extras/ShapeUtils';
-import { Matrix3, Vector2, Vector3 } from 'three';
-import { MTextFormatParser } from 'dxf-viewer/src/MTextFormatParser';
+import { DxfScene3D, Entity } from './DxfScene3D';
+import { MTextFormatParser } from './MTextFormatParser';
 
 /**
  * Helper class for rendering text.


### PR DESCRIPTION
Release:
- fix imports to use the project files instead of an implicit client dependency.
- align versioning to keep the version of the upstream. Keeps a cleaner view of the fork + avoids the tag clash altogether rather than hiding it by reversing the version to 0.0.0.